### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/dist/smooth-tween.min.js
+++ b/dist/smooth-tween.min.js
@@ -52007,7 +52007,7 @@ var _lodash = require('lodash');
 
 var _lodash2 = _interopRequireDefault(_lodash);
 
-var _nodeUuid = require('node-uuid');
+var _nodeUuid = require('uuid');
 
 var _nodeUuid2 = _interopRequireDefault(_nodeUuid);
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eases": "^1.0.8",
     "jquery": "^3.0.0",
     "lodash": "^4.13.1",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "velocity-animate": "^1.2.3"
   },
   "directories": {

--- a/src/tweenHelpers/index.js
+++ b/src/tweenHelpers/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import easingFunctions from 'eases';
 
 export function getFinishedAnimations__withTweenValue(animation, scrollTop) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.